### PR TITLE
login flow improvement

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -7,6 +7,11 @@ BINARY_NAME=mysocketctl
 
 all: test build
 
+release:
+	GOOS=windows GOARCH=amd64 go build -o ./bin/$(BINARY_NAME)_windows_amd64
+	GOOS=linux GOARCH=amd64 go build -o ./bin/$(BINARY_NAME)_linux_amd64
+	GOOS=darwin GOARCH=amd64 go build -o ./bin/$(BINARY_NAME)_darwin_amd64
+
 build:
 	$(GOBUILD) -o $(BINARY_NAME) -v
 

--- a/go/cmd/login.go
+++ b/go/cmd/login.go
@@ -55,13 +55,14 @@ var loginCmd = &cobra.Command{
 				os.Exit(1)
 			}
 			password = string(bytesPassword)
+			fmt.Print("\n")
 		}
 		err2 := http.Login(email, password)
 		if err2 != nil {
 			log.Fatalf("error: %v", err2)
 		}
 
-		fmt.Println("login successful")
+		fmt.Println("Login successful")
 	},
 }
 

--- a/go/cmd/login.go
+++ b/go/cmd/login.go
@@ -20,8 +20,11 @@ import (
 	"log"
 	"regexp"
 
+	"os"
+
 	"github.com/atoonk/mysocketctl/go/internal/http"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // loginCmd represents the login command
@@ -29,18 +32,33 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Login to mysocket and get a token",
 	Run: func(cmd *cobra.Command, args []string) {
-
+		// If email is not provided, then prompt for it
+		if email == "" {
+			fmt.Print("Email: ")
+			fmt.Scanln(&email)
+		}
+		// Let's check if the email is a valid email address
 		var emailRegex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 		if len(email) < 3 && len(email) > 254 {
 			log.Fatalf("error: invalid email address: %s", email)
 		}
-		if ! emailRegex.MatchString(email) {
+		if !emailRegex.MatchString(email) {
 			log.Fatalf("error: invalid email address: %s", email)
 		}
 
-		err := http.Login(email, password)
-		if err != nil {
-			log.Fatalf("error: %v", err)
+		// If password is not provided, then prompt for it.
+		if password == "" {
+			fmt.Print("Password: ")
+			bytesPassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+			if err != nil {
+				fmt.Printf("Error getting password from prompt: %s \n", err)
+				os.Exit(1)
+			}
+			password = string(bytesPassword)
+		}
+		err2 := http.Login(email, password)
+		if err2 != nil {
+			log.Fatalf("error: %v", err2)
 		}
 
 		fmt.Println("login successful")
@@ -50,8 +68,5 @@ var loginCmd = &cobra.Command{
 func init() {
 	loginCmd.Flags().StringVarP(&email, "email", "e", "", "Email address")
 	loginCmd.Flags().StringVarP(&password, "password", "p", "", "Password")
-	loginCmd.MarkFlagRequired("email")
-	loginCmd.MarkFlagRequired("password")
-
 	rootCmd.AddCommand(loginCmd)
 }

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -32,6 +32,7 @@ var (
 	socketType          string
 	password            string
 	port                int
+	hostname            string
 	sshkey              string
 	protected           bool
 	username            string
@@ -98,7 +99,7 @@ func initConfig() {
 	}
 }
 
-func splitLongLines(b string, maxLength int) (string) {
+func splitLongLines(b string, maxLength int) string {
 	s := ""
 	for {
 		if len(b) > maxLength {

--- a/go/cmd/tunnel.go
+++ b/go/cmd/tunnel.go
@@ -18,13 +18,13 @@ package cmd
 import (
 	"fmt"
 	"log"
-        "os"
-        "os/signal"
+	"os"
+	"os/signal"
 
 	"github.com/atoonk/mysocketctl/go/internal/http"
 	"github.com/atoonk/mysocketctl/go/internal/ssh"
-	"github.com/spf13/cobra"
 	"github.com/jedib0t/go-pretty/table"
+	"github.com/spf13/cobra"
 )
 
 // tunnelCmd represents the tunnel command
@@ -121,18 +121,18 @@ var tunnelConnectCmd = &cobra.Command{
 
 		userIDStr := *userID
 
-                // Handle control + C
-                c := make(chan os.Signal, 1)
-                signal.Notify(c, os.Interrupt)
-                go func() {
-                        for {
-                                <-c
-                                log.Print("User disconnected...")
-                                os.Exit(0)
-                        }
-                }()
+		// Handle control + C
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		go func() {
+			for {
+				<-c
+				log.Print("User disconnected...")
+				os.Exit(0)
+			}
+		}()
 
-		ssh.SshConnect(userIDStr, socketID, tunnelID, port, identityFile)
+		ssh.SshConnect(userIDStr, socketID, tunnelID, port, hostname, identityFile)
 	},
 }
 
@@ -165,6 +165,7 @@ func init() {
 	tunnelConnectCmd.Flags().StringVarP(&socketID, "socket_id", "s", "", "Socket ID")
 	tunnelConnectCmd.Flags().StringVarP(&identityFile, "identity_file", "i", "", "Identity File")
 	tunnelConnectCmd.Flags().IntVarP(&port, "port", "p", 0, "Port number")
+	tunnelConnectCmd.Flags().StringVarP(&hostname, "host", "", "127.0.0.1", "Target host: Control where inbound traffic goes. Default localhost")
 	tunnelConnectCmd.MarkFlagRequired("tunnel_id")
 	tunnelConnectCmd.MarkFlagRequired("socket_id")
 	tunnelConnectCmd.MarkFlagRequired("port")

--- a/go/internal/ssh/handler.go
+++ b/go/internal/ssh/handler.go
@@ -24,7 +24,7 @@ func SSHAgent() ssh.AuthMethod {
 	return nil
 }
 
-func SshConnect(userID string, socketID string, tunnelID string, port int, identityFile string) error {
+func SshConnect(userID string, socketID string, tunnelID string, port int, targethost string, identityFile string) error {
 	tunnel, err := http.GetTunnel(socketID, tunnelID)
 
 	if err != nil {
@@ -104,7 +104,7 @@ func SshConnect(userID string, socketID string, tunnelID string, port int, ident
 				continue
 			}
 
-			local, err := net.Dial("tcp", fmt.Sprintf("%s:%d", "localhost", port))
+			local, err := net.Dial("tcp", fmt.Sprintf("%s:%d", targethost, port))
 			if err != nil {
 				log.Printf("Dial INTO local service error: %s", err)
 				continue


### PR DESCRIPTION
with this change, for login, email add password flags become optional.
if either or both is not set using --email or --password, it will prompt for it.

old ```--email``` and ```--password``` options will still work.

new option:
```
$ ./mysocketctl login
Email: atoonk@gmail.com
Password:
Login successful
```