### PR TITLE
change to login flow

### DIFF
--- a/go/cmd/login.go
+++ b/go/cmd/login.go
@@ -20,8 +20,11 @@ import (
 	"log"
 	"regexp"
 
+	"os"
+
 	"github.com/atoonk/mysocketctl/go/internal/http"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // loginCmd represents the login command
@@ -29,29 +32,42 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Login to mysocket and get a token",
 	Run: func(cmd *cobra.Command, args []string) {
-
+		// If email is not provided, then prompt for it
+		if email == "" {
+			fmt.Print("Email: ")
+			fmt.Scanln(&email)
+		}
+		// Let's check if the email is a valid email address
 		var emailRegex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 		if len(email) < 3 && len(email) > 254 {
 			log.Fatalf("error: invalid email address: %s", email)
 		}
-		if ! emailRegex.MatchString(email) {
+		if !emailRegex.MatchString(email) {
 			log.Fatalf("error: invalid email address: %s", email)
 		}
 
-		err := http.Login(email, password)
-		if err != nil {
-			log.Fatalf("error: %v", err)
+		// If password is not provided, then prompt for it.
+		if password == "" {
+			fmt.Print("Password: ")
+			bytesPassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+			if err != nil {
+				fmt.Printf("Error getting password from prompt: %s \n", err)
+				os.Exit(1)
+			}
+			password = string(bytesPassword)
+			fmt.Print("\n")
+		}
+		err2 := http.Login(email, password)
+		if err2 != nil {
+			log.Fatalf("error: %v", err2)
 		}
 
-		fmt.Println("login successful")
+		fmt.Println("Login successful")
 	},
 }
 
 func init() {
 	loginCmd.Flags().StringVarP(&email, "email", "e", "", "Email address")
 	loginCmd.Flags().StringVarP(&password, "password", "p", "", "Password")
-	loginCmd.MarkFlagRequired("email")
-	loginCmd.MarkFlagRequired("password")
-
 	rootCmd.AddCommand(loginCmd)
 }


### PR DESCRIPTION
with this change, for login, email add password flags become optional.
if either or both is not set using --email or --password, it will prompt for it.

old ```--email``` and ```--password``` options will still work.

new option:
```
$ ./mysocketctl login
Email: atoonk@gmail.com
Password:
Login successful
```