### PR TITLE
adding support for version check and upgrade

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,5 +1,6 @@
 GOCMD=go
 GOBUILD=$(GOCMD) build
+GOFMT=$(GOCMD)fmt
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
@@ -10,15 +11,25 @@ DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
 VERSION := $(shell git describe --long --dirty --tags)
 FLAGS := -ldflags "-X github.com/atoonk/mysocketctl/go/cmd.version=$(VERSION) -X github.com/atoonk/mysocketctl/go/cmd.date=$(DATE)"
 
-all: test build
+all: lint test build
 
 release:
 	GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
 	GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
 	GOOS=darwin GOARCH=amd64 go build $(FLAGS)  -o ./bin/$(BINARY_NAME)_darwin_amd64
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64 ${BUCKET} macos/mysocketctl
+
+	shasum -a 256 ./bin/mysocketctl_darwin_amd64 | awk '{print $$1}' > ./bin/mysocketctl_darwin_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64-sha256-checksum.txt ${BUCKET} darwin_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64 ${BUCKET} darwin_amd64/mysocketctl
+
+	shasum -a 256 ./bin/mysocketctl_linux_amd64 | awk '{print $$1}' > ./bin/mysocketctl_linux_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64-sha256-checksum.txt ${BUCKET} linux_amd64/sha256-checksum.txt
 	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64 ${BUCKET} linux_amd64/mysocketctl
+
+	shasum -a 256 ./bin/mysocketctl_windows_amd64 | awk '{print $$1}' > ./bin/mysocketctl_windows_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64-sha256-checksum.txt ${BUCKET} windows_amd64/sha256-checksum.txt
 	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64 ${BUCKET} windows_amd64/mysocketctl
+
 	echo ${VERSION} > latest_version.txt
 	python3 ./s3upload.py latest_version.txt ${BUCKET} latest_version.txt
 	rm latest_version.txt
@@ -29,6 +40,10 @@ build:
 
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v
+
+lint:
+	@echo "running go fmt"
+	$(GOFMT) -w .
 
 test:
 	$(GOTEST) -v ./...

--- a/go/cmd/account.go
+++ b/go/cmd/account.go
@@ -17,18 +17,18 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
-	"io/ioutil"
 
 	"github.com/atoonk/mysocketctl/go/internal/http"
-	"github.com/spf13/cobra"
 	"github.com/jedib0t/go-pretty/table"
+	"github.com/spf13/cobra"
 )
 
 // accountCmd represents the account command
 var accountCmd = &cobra.Command{
-	Use: "account",
+	Use:   "account",
 	Short: "Create a new account or see account information.",
 }
 

--- a/go/cmd/login.go
+++ b/go/cmd/login.go
@@ -32,6 +32,18 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Login to mysocket and get a token",
 	Run: func(cmd *cobra.Command, args []string) {
+
+        // Do version check
+        latest_version, err := http.GetLatestVersion()
+        if err != nil {
+            log.Fatalf("error while checking for latest version: %v", err)
+        }
+        if latest_version != version {
+            binary_path  := os.Args[0]
+            fmt.Printf("New version available. Please upgrade:\n%s version upgrade\n\n", binary_path)
+        }
+        // end version check
+
 		// If email is not provided, then prompt for it
 		if email == "" {
 			fmt.Print("Email: ")

--- a/go/cmd/login.go
+++ b/go/cmd/login.go
@@ -33,16 +33,16 @@ var loginCmd = &cobra.Command{
 	Short: "Login to mysocket and get a token",
 	Run: func(cmd *cobra.Command, args []string) {
 
-        // Do version check
-        latest_version, err := http.GetLatestVersion()
-        if err != nil {
-            log.Fatalf("error while checking for latest version: %v", err)
-        }
-        if latest_version != version {
-            binary_path  := os.Args[0]
-            fmt.Printf("New version available. Please upgrade:\n%s version upgrade\n\n", binary_path)
-        }
-        // end version check
+		// Do version check
+		latest_version, err := http.GetLatestVersion()
+		if err != nil {
+			log.Fatalf("error while checking for latest version: %v", err)
+		}
+		if latest_version != version {
+			binary_path := os.Args[0]
+			fmt.Printf("New version available. Please upgrade:\n%s version upgrade\n\n", binary_path)
+		}
+		// end version check
 
 		// If email is not provided, then prompt for it
 		if email == "" {

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -48,8 +48,8 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "mysocketctl",
-	Short: "mysocket.io command line interface (CLI)",
+	Use:     "mysocketctl",
+	Short:   "mysocket.io command line interface (CLI)",
 	Version: version,
 }
 
@@ -63,7 +63,7 @@ func Execute() {
 }
 
 func init() {
-        rootCmd.SetVersionTemplate(fmt.Sprintf("mysocketctl:\nversion %s\ndate: %s\n", version, date))
+	rootCmd.SetVersionTemplate(fmt.Sprintf("mysocketctl:\nversion %s\ndate: %s\n", version, date))
 	cobra.OnInitialize(initConfig)
 }
 

--- a/go/cmd/socket.go
+++ b/go/cmd/socket.go
@@ -18,13 +18,13 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
-	"regexp"
 
 	"github.com/atoonk/mysocketctl/go/internal/http"
-	"github.com/spf13/cobra"
 	"github.com/jedib0t/go-pretty/table"
+	"github.com/spf13/cobra"
 )
 
 // socketCmd represents the socket command
@@ -91,7 +91,7 @@ var socketCreateCmd = &cobra.Command{
 		if cloudauth {
 			for _, a := range strings.Split(cloudauth_addresses, ",") {
 				email := strings.TrimSpace(a)
-		                if emailRegex.MatchString(email) {
+				if emailRegex.MatchString(email) {
 					allowedEmailAddresses = append(allowedEmailAddresses, email)
 				} else {
 					log.Printf("Warning: ignoring invalid email %s", email)
@@ -128,14 +128,14 @@ var socketCreateCmd = &cobra.Command{
 		}
 
 		t.AppendRow(table.Row{s.SocketID, s.Dnsname, portsStr, s.SocketType, s.CloudAuthEnabled, s.Name})
-                t.SetStyle(table.StyleLight)
-                fmt.Printf("%s\n", t.Render())
+		t.SetStyle(table.StyleLight)
+		fmt.Printf("%s\n", t.Render())
 
 		if s.ProtectedSocket {
 			tp := table.NewWriter()
 			tp.AppendHeader(table.Row{"Username", "Password"})
 			tp.AppendRow(table.Row{s.ProtectedUsername, s.ProtectedPassword})
-	                tp.SetStyle(table.StyleLight)
+			tp.SetStyle(table.StyleLight)
 			fmt.Printf("\nProtected Socket:\n%s\n", tp.Render())
 		}
 
@@ -143,7 +143,7 @@ var socketCreateCmd = &cobra.Command{
 			tc := table.NewWriter()
 			tc.AppendHeader(table.Row{"Allowed email addresses", "Allowed email domains"})
 			tc.AppendRow(table.Row{strings.Join(s.AllowedEmailAddresses, "\n"), strings.Join(s.AllowedEmailDomains, "\n")})
-	                tc.SetStyle(table.StyleLight)
+			tc.SetStyle(table.StyleLight)
 			fmt.Printf("\nCloud Authentication, login details:\n%s\n", tc.Render())
 		}
 	},

--- a/go/cmd/version.go
+++ b/go/cmd/version.go
@@ -9,22 +9,22 @@ You may obtain a copy of the License at
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+WITHOUT WARR    ANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 package cmd
 
 import (
-    "os"
-    "fmt"
-    "log"
-    "io/ioutil"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"runtime"
+
 	"github.com/atoonk/mysocketctl/go/internal/http"
 	"github.com/spf13/cobra"
 )
-
-
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -67,7 +67,7 @@ var upgradeVersionCmd = &cobra.Command{
                 return
             }
 
-            latest, err := http.GetLatestBinary()
+            latest, err := http.GetLatestBinary(runtime.GOOS)
             if latest == nil {
                 log.Fatalf("Error while downloading latest version %v", err)
             }

--- a/go/cmd/version.go
+++ b/go/cmd/version.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+    "os"
+    "fmt"
+    "log"
+    "io/ioutil"
+	"github.com/atoonk/mysocketctl/go/internal/http"
+	"github.com/spf13/cobra"
+)
+
+
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use: "version",
+	Short: "check version",
+}
+
+var checkLatestVersionCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check to see if you're running the latest version",
+	Run: func(cmd *cobra.Command, args []string) {
+            latest_version, err := http.GetLatestVersion()
+            if err != nil {
+                log.Fatalf("error while checking for latest version: %v", err)
+            }
+            if latest_version != version {
+                binary_path  := os.Args[0]
+                fmt.Printf("You're running version %s\n\n",version)
+                fmt.Printf("There is a newer version available (%s)!\n", latest_version)
+                fmt.Printf("Please upgrade:\n%s version upgrade\n", binary_path)
+            } else {
+                fmt.Printf("You are up to date!\n")
+                fmt.Printf("You're running version %s\n",version)
+            }
+	},
+}
+var upgradeVersionCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "upgrade the latest version",
+	Run: func(cmd *cobra.Command, args []string) {
+            binary_path  := os.Args[0]
+            latest_version, err := http.GetLatestVersion()
+            if err != nil {
+                log.Fatalf("error while checking for latest version: %v", err)
+            }
+            if latest_version != version {
+                fmt.Printf("Upgrading %s to version %s\n",binary_path,latest_version)
+            } else {
+                fmt.Printf("You are up to date already :)\n")
+                return
+            }
+
+            latest, err := http.GetLatestBinary()
+            if latest == nil {
+                log.Fatalf("Error while downloading latest version %v", err)
+            }
+
+            err = ioutil.WriteFile(binary_path, latest, 0644)
+	        if err != nil {
+                log.Fatalf("Error while writing new file: %v", err)
+	        }
+            fmt.Printf("Upgrade completed\n")
+	},
+}
+
+
+func init() {
+	versionCmd.AddCommand(checkLatestVersionCmd)
+	versionCmd.AddCommand(upgradeVersionCmd)
+	rootCmd.AddCommand(versionCmd)
+}

--- a/go/internal/http/handler.go
+++ b/go/internal/http/handler.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	mysocketurl = "https://api.mysocket.io"
+	download_url = "https://download.edge.mysocket.io"
 )
 
 var (
@@ -91,6 +92,51 @@ func Register(name, email, password, sshkey string) error {
 		return errors.New(fmt.Sprintf("failed to register user %d\n%v", resp.StatusCode, string(responseData)))
 	}
 	return nil
+}
+
+
+func GetLatestVersion() (string, error) {
+    client := &h.Client{}
+	req, err := h.NewRequest("GET", download_url + "/latest_version.txt", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", errors.New(fmt.Sprintf("Version check failed. Failed to get latest version (%d)", resp.StatusCode))
+	}
+    bodyBytes, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+            return "",err
+    }
+    bodyString := string(bodyBytes)
+    version := strings.TrimSpace(string(bodyString))
+    version = strings.TrimSuffix(version, "\n")
+    return version,  nil
+}
+
+func GetLatestBinary() ([]byte , error) {
+    client := &h.Client{}
+	req, err := h.NewRequest("GET", download_url +"/macos/mysocketctl", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, errors.New(fmt.Sprintf("Failed to get latest version (%d)", resp.StatusCode))
+	}
+    bodyBytes, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+            return nil, err
+    }
+    return bodyBytes,  nil
 }
 
 func GetToken() (string, error) {

--- a/go/internal/http/handler.go
+++ b/go/internal/http/handler.go
@@ -5,15 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
 	"io/ioutil"
 	h "net/http"
 	"os"
 	"strings"
+
+	"github.com/dgrijalva/jwt-go"
 )
 
 const (
-	mysocketurl = "https://api.mysocket.io"
+	mysocketurl  = "https://api.mysocket.io"
 	download_url = "https://download.edge.mysocket.io"
 )
 
@@ -85,7 +86,7 @@ func Register(name, email, password, sshkey string) error {
 		return err
 	}
 
-        defer resp.Body.Close()
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		responseData, _ := ioutil.ReadAll(resp.Body)
@@ -94,34 +95,44 @@ func Register(name, email, password, sshkey string) error {
 	return nil
 }
 
-
 func GetLatestVersion() (string, error) {
-    client := &h.Client{}
-	req, err := h.NewRequest("GET", download_url + "/latest_version.txt", nil)
+	client := &h.Client{}
+	req, err := h.NewRequest("GET", download_url+"/latest_version.txt", nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
-
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return "", errors.New(fmt.Sprintf("Version check failed. Failed to get latest version (%d)", resp.StatusCode))
 	}
-    bodyBytes, err := ioutil.ReadAll(resp.Body)
-        if err != nil {
-            return "",err
-    }
-    bodyString := string(bodyBytes)
-    version := strings.TrimSpace(string(bodyString))
-    version = strings.TrimSuffix(version, "\n")
-    return version,  nil
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	bodyString := string(bodyBytes)
+	version := strings.TrimSpace(string(bodyString))
+	version = strings.TrimSuffix(version, "\n")
+	return version, nil
 }
 
-func GetLatestBinary() ([]byte , error) {
-    client := &h.Client{}
-	req, err := h.NewRequest("GET", download_url +"/macos/mysocketctl", nil)
+func GetLatestBinary(osname string) ([]byte, error) {
+	var url string
+	switch osname {
+	case "darwin":
+		url = download_url + "/macos/mysocketctl"
+	case "linux":
+		url = download_url + "/linux/mysocketctl"
+	case "windows":
+		url = download_url + "/windows/mysocketctl"
+	default:
+		return nil, errors.New(fmt.Sprintf("unknown OS: %s", osname))
+	}
+
+	client := &h.Client{}
+	req, err := h.NewRequest("GET", url, nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -132,11 +143,11 @@ func GetLatestBinary() ([]byte , error) {
 	if resp.StatusCode != 200 {
 		return nil, errors.New(fmt.Sprintf("Failed to get latest version (%d)", resp.StatusCode))
 	}
-    bodyBytes, err := ioutil.ReadAll(resp.Body)
-        if err != nil {
-            return nil, err
-    }
-    return bodyBytes,  nil
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return bodyBytes, nil
 }
 
 func GetToken() (string, error) {
@@ -417,9 +428,9 @@ func CreateConnection(name string, protected bool, username string, password str
 		SocketType:            socketType,
 		ProtectedUsername:     username,
 		ProtectedPassword:     password,
-                CloudAuthEnabled:      cloudAuthEnabled,
-                AllowedEmailAddresses: allowedEmailAddresses,
-                AllowedEmailDomains:   allowedEmailDomains,
+		CloudAuthEnabled:      cloudAuthEnabled,
+		AllowedEmailAddresses: allowedEmailAddresses,
+		AllowedEmailDomains:   allowedEmailDomains,
 	}
 
 	jv, _ := json.Marshal(s)

--- a/go/internal/http/models.go
+++ b/go/internal/http/models.go
@@ -43,6 +43,3 @@ type Tunnel struct {
 	LocalPort    int    `json:"local_port,omitempty"`
 	TunnelServer string `json:"tunnel_server,omitempty"`
 }
-type LatestVersion struct {
-	version     string
-}

--- a/go/internal/http/models.go
+++ b/go/internal/http/models.go
@@ -23,19 +23,19 @@ type Account struct {
 }
 
 type Socket struct {
-	Tunnels                []Tunnel `json:"tunnels,omitempty"`
-	Username               string   `json:"user_name,omitempty"`
-	SocketID               string   `json:"socket_id,omitempty"`
-	SocketTcpPorts         []int    `json:"socket_tcp_ports,omitempty"`
-	Dnsname                string   `json:"dnsname,omitempty"`
-	Name                   string   `json:"name,omitempty"`
-	SocketType             string   `json:"socket_type,omitempty"`
-	ProtectedSocket        bool     `json:"protected_socket"`
-	ProtectedUsername      string   `json:"protected_username"`
-	ProtectedPassword      string   `json:"protected_password"`
-	CloudAuthEnabled       bool     `json:"cloud_authentication_enabled,omitempty"`
-	AllowedEmailAddresses  []string `json:"cloud_authentication_email_allowed_addressses,omitempty"`
-	AllowedEmailDomains    []string `json:"cloud_authentication_email_allowed_domains,omitempty"`
+	Tunnels               []Tunnel `json:"tunnels,omitempty"`
+	Username              string   `json:"user_name,omitempty"`
+	SocketID              string   `json:"socket_id,omitempty"`
+	SocketTcpPorts        []int    `json:"socket_tcp_ports,omitempty"`
+	Dnsname               string   `json:"dnsname,omitempty"`
+	Name                  string   `json:"name,omitempty"`
+	SocketType            string   `json:"socket_type,omitempty"`
+	ProtectedSocket       bool     `json:"protected_socket"`
+	ProtectedUsername     string   `json:"protected_username"`
+	ProtectedPassword     string   `json:"protected_password"`
+	CloudAuthEnabled      bool     `json:"cloud_authentication_enabled,omitempty"`
+	AllowedEmailAddresses []string `json:"cloud_authentication_email_allowed_addressses,omitempty"`
+	AllowedEmailDomains   []string `json:"cloud_authentication_email_allowed_domains,omitempty"`
 }
 
 type Tunnel struct {

--- a/go/internal/http/models.go
+++ b/go/internal/http/models.go
@@ -43,3 +43,6 @@ type Tunnel struct {
 	LocalPort    int    `json:"local_port,omitempty"`
 	TunnelServer string `json:"tunnel_server,omitempty"`
 }
+type LatestVersion struct {
+	version     string
+}

--- a/go/internal/ssh/handler.go
+++ b/go/internal/ssh/handler.go
@@ -7,10 +7,10 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"io"
 	"io/ioutil"
-	"time"
 	"log"
 	"net"
 	"os"
+	"time"
 )
 
 const (
@@ -19,8 +19,7 @@ const (
 )
 
 var (
-	defaultKeyFiles   = []string{"id_dsa","id_ecdsa","id_ed25519", "id_rsa"}
-
+	defaultKeyFiles = []string{"id_dsa", "id_ecdsa", "id_ed25519", "id_rsa"}
 )
 
 func SshConnect(userID string, socketID string, tunnelID string, port int, targethost string, identityFile string) error {
@@ -30,13 +29,13 @@ func SshConnect(userID string, socketID string, tunnelID string, port int, targe
 		log.Fatalf("error: %v", err)
 	}
 
-        sshConfig := &ssh.ClientConfig{
-                User: userID,
-                HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout: defaultTimeout,
-        }
-        var keyFiles []string
-        var signers []ssh.Signer
+	sshConfig := &ssh.ClientConfig{
+		User:            userID,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         defaultTimeout,
+	}
+	var keyFiles []string
+	var signers []ssh.Signer
 
 	if identityFile != "" {
 		f := []string{identityFile}
@@ -49,15 +48,15 @@ func SshConnect(userID string, socketID string, tunnelID string, port int, targe
 		signers = append(signers, auth...)
 	}
 
-        home, err := os.UserHomeDir()
-        if err == nil {
-                for _, k := range defaultKeyFiles {
-                        f := home+"/.ssh/"+k
-                        if _, err := os.Stat(f); err == nil {
+	home, err := os.UserHomeDir()
+	if err == nil {
+		for _, k := range defaultKeyFiles {
+			f := home + "/.ssh/" + k
+			if _, err := os.Stat(f); err == nil {
 				keyFiles = append(keyFiles, f)
-                        }
-                }
-        }
+			}
+		}
+	}
 
 	if auth, err := authWithPrivateKeys(keyFiles, false); err == nil {
 		signers = append(signers, auth...)
@@ -104,18 +103,18 @@ func SshConnect(userID string, socketID string, tunnelID string, port int, targe
 			continue
 		}
 
-/*
-		// Handle control + C
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt)
-		go func() {
-			for {
-				<-c
-				log.Print("User disconnected...")
-				return
-			}
-		}()
-*/
+		/*
+			// Handle control + C
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, os.Interrupt)
+			go func() {
+				for {
+					<-c
+					log.Print("User disconnected...")
+					return
+				}
+			}()
+		*/
 
 		for {
 			client, err := listener.Accept()
@@ -169,40 +168,40 @@ func ioCopy(dst io.Writer, src io.Reader) {
 }
 
 func authWithPrivateKeys(keyFiles []string, fatalOnError bool) ([]ssh.Signer, error) {
-        var signers []ssh.Signer
+	var signers []ssh.Signer
 
-        for _, file := range keyFiles {
+	for _, file := range keyFiles {
 
-                b, err := ioutil.ReadFile(file)
-                if err != nil {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
 			if fatalOnError {
 				log.Fatalln(fmt.Sprintf("Cannot read SSH key file %s (%v)", file, err.Error()))
 			} else {
 				continue
 			}
-                }
-                signer, err := ssh.ParsePrivateKey(b)
-                if err != nil {
-                        if fatalOnError {
-                                log.Fatalln(fmt.Sprintf("Cannot read SSH key file %s (%v)", file, err.Error()))
+		}
+		signer, err := ssh.ParsePrivateKey(b)
+		if err != nil {
+			if fatalOnError {
+				log.Fatalln(fmt.Sprintf("Cannot read SSH key file %s (%v)", file, err.Error()))
 			} else {
 				continue
 			}
-                }
-                signers = append(signers, signer)
-        }
+		}
+		signers = append(signers, signer)
+	}
 
-        return signers, nil
+	return signers, nil
 }
 
 func authWithAgent() ([]ssh.Signer, error) {
-        if os.Getenv("SSH_AUTH_SOCK") != "" {
-                sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
-                if err == nil {
-                        agentSigners, _ := agent.NewClient(sshAgent).Signers()
-                        return agentSigners, nil
-                }
-        }
+	if os.Getenv("SSH_AUTH_SOCK") != "" {
+		sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+		if err == nil {
+			agentSigners, _ := agent.NewClient(sshAgent).Signers()
+			return agentSigners, nil
+		}
+	}
 
-        return nil, nil
+	return nil, nil
 }

--- a/go/s3upload.py
+++ b/go/s3upload.py
@@ -6,7 +6,6 @@ from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
 
 
-
 def upload_to_aws(local_file, bucket, s3_file):
     s3 = boto3.client('s3' )
     args={}


### PR DESCRIPTION
adding support for version check and upgrade
version check is also a run during each login

Version Check:

```
$ ./mysocketctl version check
You're running version 0.42.0-34-gade6888-dirty

There is a newer version available (0.42.0-41-g782125a)!
Please upgrade:
./mysocketctl version upgrade
```

Version upgrade overwrites the binary
```
$ ./mysocketctl version upgrade
Upgrading ./mysocketctl to version 0.42.0-41-g782125a
Upgrade completed
```

Login
```
$ ./mysocketctl login
New version available. Please upgrade:
./mysocketctl version upgrade

Email: atoonk@gmail.com
Password:
Login successful
```